### PR TITLE
chore: eslint 적용 및 prettier extenstion 활성화

### DIFF
--- a/apps/render-playground/.eslintrc.js
+++ b/apps/render-playground/.eslintrc.js
@@ -1,0 +1,9 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: ["@repo/eslint-config/next.js"],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: true,
+  },
+};

--- a/apps/render-playground/app/page.tsx
+++ b/apps/render-playground/app/page.tsx
@@ -1,45 +1,53 @@
-'use client'
+"use client";
 import { memo, useState } from "react";
 
 const InnerComponent = (props) => {
-  const {count} = props
-  if(count){
-    return <div>has count InnerComponent{count} counting</div>
+  const { count } = props;
+  if (count) {
+    return <div>has count InnerComponent{count} counting</div>;
   }
-  return <div>inner InnerComponent</div>
-}
+  return <div>inner InnerComponent</div>;
+};
 
 const MemoComponent1 = memo(() => {
-  console.log('no props')
-  return (<div>non memo</div>)
-})
+  console.log("no props");
+  return <div>non memo</div>;
+});
 
-const MemoComponent2 = memo((props: {memoCount: number}) => {
-  console.log('here')
-  return (<div>counting memo: {props.memoCount}</div>)
-})
-
+const MemoComponent2 = memo((props: { memoCount: number }) => {
+  console.log("here");
+  return <div>counting memo: {props.memoCount}</div>;
+});
 
 function Home(props) {
-  const [count, setCount] = useState(0)
-  const [memoCount, setMemoCount] = useState(0)
-  
+  const [count, setCount] = useState(0);
+  const [memoCount, setMemoCount] = useState(0);
+
   return (
     <div>
       <div>render-playground - devtools render check</div>
-      <ul>devtools의 render는 Render Phase를 의미. 자신의 상태가 변경되거나, props가 변경되거나, 부모가 변경되어서 하위값들이 render phase 진입</ul>
+      <ul>
+        devtools의 render는 Render Phase를 의미. 자신의 상태가 변경되거나,
+        props가 변경되거나, 부모가 변경되어서 하위값들이 render phase 진입
+      </ul>
       <div>count: {count}</div>
       <div>memoCount: {memoCount}</div>
-      <div onClick={() => setMemoCount(prev => prev+ 1)}>memo updater</div>
-    <div onClick={() => setCount(prev => prev + 1)}>click</div>
-    <div><InnerComponent count={count} /></div>
-    <MemoComponent1  />
-    <MemoComponent2 memoCount={memoCount}  />
-    <div>{props.children}</div>
+      <div onClick={() => setMemoCount((prev) => prev + 1)}>memo updater</div>
+      <div onClick={() => setCount((prev) => prev + 1)}>click</div>
+      <div>
+        <InnerComponent count={count} />
+      </div>
+      <MemoComponent1 />
+      <MemoComponent2 memoCount={memoCount} />
+      <div>{props.children}</div>
     </div>
   );
 }
 export default function PageHome() {
-  const [hoeme, setHome] = useState('home')
- return (<Home>여기는 children {hoeme}  <InnerComponent/>  </Home>)
+  const [hoeme, setHome] = useState("home");
+  return (
+    <Home>
+      여기는 children {hoeme} <InnerComponent />{" "}
+    </Home>
+  );
 }

--- a/apps/render-playground/package.json
+++ b/apps/render-playground/package.json
@@ -9,7 +9,7 @@
     "lint": "echo 'Add lint script here'"
   },
   "dependencies": {
-    "@repo/eslint-config": "*",
+    "@repo/eslint-config": "^0.0.0",
     "@repo/typescript-config": "*",
     "@repo/ui": "*",
     "next": "^14.2.8",

--- a/apps/render-playground/tsconfig.json
+++ b/apps/render-playground/tsconfig.json
@@ -1,21 +1,6 @@
 {
-  "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": false,
-    "noEmit": true,
-    "incremental": true,
-    "module": "esnext",
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
+   "extends": "@repo/typescript-config/nextjs.json", 
+   "compilerOptions": {
     "plugins": [
       {
         "name": "next"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
     "apps/render-playground": {
       "version": "0.0.0",
       "dependencies": {
-        "@repo/eslint-config": "*",
+        "@repo/eslint-config": "^0.0.0",
         "@repo/typescript-config": "*",
         "@repo/ui": "*",
         "next": "^14.2.8",


### PR DESCRIPTION
## note
> [참고링크](https://valcker.medium.com/unpacking-turborepo-configure-typescript-monorepo-with-eslint-prettier-and-webstorm-960bf9e65e60)

- 새롭게 생성한 render-playground에서 외부 eslint를 끌고 들어와서 적용
